### PR TITLE
Bind Optimus class to Laravel container

### DIFF
--- a/src/FakeIdServiceProvider.php
+++ b/src/FakeIdServiceProvider.php
@@ -53,6 +53,10 @@ class FakeIdServiceProvider extends ServiceProvider
 			);
 		});
 
+		$this->app->bind(Optimus::class, function ($app) {
+			return $app['fakeid'];
+		});
+
 		$this->registerRouterMacro();
 
 	}


### PR DESCRIPTION
This is to make it easy to get the Optimus instance injected into other classes.
