### PR TITLE
typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Next, simply import `Propaganistas\LaravelFakeId\FakeIdTrait` into your model:
 
 ```php
 use Illuminate\Database\Eloquent\Model;
-use Propaganistas\LaravalFakeId\FakeIdTrait;
+use Propaganistas\LaravelFakeId\FakeIdTrait;
 
 class MyModel extends Model {
 


### PR DESCRIPTION
The typo @javaftper fixed in https://github.com/Propaganistas/Laravel-FakeId/issues/2 existed twice.
