### PR TITLE
Throw NotFoundHttpException when debug is disabled

### DIFF
--- a/src/FakeIdServiceProvider.php
+++ b/src/FakeIdServiceProvider.php
@@ -69,7 +69,11 @@ class FakeIdServiceProvider extends ServiceProvider
 
                 // Decode FakeId first if applicable.
                 if (in_array('Propaganistas\LaravelFakeId\FakeIdTrait', class_uses_recursive($class))) {
-                    $value = $this->container->make('fakeid')->decode($value);
+                    try {
+                        $value = $this->container->make('fakeid')->decode($value);
+                    } catch (\InvalidArgumentException $e) {
+                        throw config('app.debug') ? new  \InvalidArgumentException($e->getMessage()) : new NotFoundHttpException;
+                    }
                 }
 
                 if ($model = $instance->where($instance->getRouteKeyName(), $value)->first()) {

--- a/src/FakeIdServiceProvider.php
+++ b/src/FakeIdServiceProvider.php
@@ -72,7 +72,7 @@ class FakeIdServiceProvider extends ServiceProvider
                     try {
                         $value = $this->container->make('fakeid')->decode($value);
                     } catch (\InvalidArgumentException $e) {
-                        throw config('app.debug') ? new  \InvalidArgumentException($e->getMessage()) : new NotFoundHttpException;
+                        throw config('app.debug') ? $e : new NotFoundHttpException;
                     }
                 }
 

--- a/tests/Entities/Fake.php
+++ b/tests/Entities/Fake.php
@@ -1,0 +1,10 @@
+<?php
+namespace Propaganistas\LaravelFakeId\Tests\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Propaganistas\LaravelFakeId\FakeIdTrait;
+
+class Fake extends Model
+{
+    use FakeIdTrait;
+}

--- a/tests/Entities/Real.php
+++ b/tests/Entities/Real.php
@@ -1,0 +1,9 @@
+<?php
+namespace Propaganistas\LaravelFakeId\Tests\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Real extends Model
+{
+
+}

--- a/tests/FakeIdTest.php
+++ b/tests/FakeIdTest.php
@@ -1,7 +1,6 @@
 <?php namespace Propaganistas\LaravelFakeId\Tests;
 
 use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Routing\Middleware\SubstituteBindings;
 use Orchestra\Testbench\TestCase;
 use Propaganistas\LaravelFakeId\Facades\FakeId;
 use Propaganistas\LaravelFakeId\Tests\Entities\Fake;
@@ -22,16 +21,16 @@ class FakeIdTest extends TestCase
 
         $this->route = $this->app['router'];
 
-        $this->route->model('real', Real::class);
-        $this->route->fakeIdModel('fake', Fake::class);
+        $this->route->model('real', 'Propaganistas\LaravelFakeId\Tests\Entities\Real');
+        $this->route->fakeIdModel('fake', 'Propaganistas\LaravelFakeId\Tests\Entities\Fake');
 
         $this->route->get('real/{real}', ['as' => 'real', function ($real) {
             return $real->id;
-        }])->middleware(SubstituteBindings::class);
+        }])->middleware('Illuminate\Routing\Middleware\SubstituteBindings');
 
         $this->route->get('fake/{fake}', ['as' => 'fake', function ($fake) {
             return $fake->id;
-        }])->middleware(SubstituteBindings::class);
+        }])->middleware('Illuminate\Routing\Middleware\SubstituteBindings');
 
     }
 


### PR DESCRIPTION
Throw NotFoundHttpException when debug is disabled and pass string in
URL

for example `http://site.com/user/1844379023` work fine but
`http://site.com/user/test` throw InvalidArgumentException