### PR TITLE
Support Laravel 5.5 auto-discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,15 @@
         "psr-4": {
             "Propaganistas\\LaravelFakeId\\Tests\\": "tests/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Propaganistas\\LaravelFakeId\\FakeIdServiceProvider"
+            ],
+            "aliases": {
+                "FakeId": "Propaganistas\\LaravelFakeId\\Facades\\FakeId"
+            }
+        }
     }
 }


### PR DESCRIPTION
This will automatically register the ServiceProvider and facade in Laravel 5.5.