### PR TITLE
Bumped compatibility range to <5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/config": ">=5.5,<5.7",
-        "illuminate/container": ">=5.5,<5.7",
-        "illuminate/routing": ">=5.5,<5.7",
-        "illuminate/support": ">=5.5,<5.7",
+        "illuminate/config": ">=5.5,<5.8",
+        "illuminate/container": ">=5.5,<5.8",
+        "illuminate/routing": ">=5.5,<5.8",
+        "illuminate/support": ">=5.5,<5.8",
         "jenssegers/optimus": "^0.2.2",
         "phpseclib/phpseclib": "^2.0"
     },


### PR DESCRIPTION
Nothing in the upgrade guide for 5.6->5.7 needs doing in this package it would appear.