### PR TITLE
Fix PHP 8.1 deprecation ctype_digit() warning

### DIFF
--- a/src/RoutesWithFakeIds.php
+++ b/src/RoutesWithFakeIds.php
@@ -15,7 +15,7 @@ trait RoutesWithFakeIds
     {
         $key = $this->getKey();
 
-        if ($this->getKeyType() === 'int' && (ctype_digit($key) || is_int($key))) {
+        if ($this->getKeyType() === 'int' && (is_int($key) || ctype_digit($key))) {
             return App::make('fakeid')->encode((int) $key);
         }
 


### PR DESCRIPTION
### Description

Since switching to PHP  8.1, our logs are getting spammed with a `ctype_digit()` deprecation warning. Because of these thousands and thousands of log entries, it sometimes happens our requests time out too.

```
ctype_digit(): Argument of type int will be interpreted as string in the future
```

### Cause

This happens because the model's key is an integer and `ctype_digit()` only accepts a string. 

> As of PHP 8.1.0, passing a non-string argument is deprecated. In the future, the argument will be interpreted as a string instead of an ASCII codepoint. Depending on the intended behavior, the argument should either be cast to string or an explicit call to [chr()](https://www.php.net/manual/en/function.chr.php) should be made.

Source: https://www.php.net/manual/en/function.ctype-digit.php

### Fix

By simply reversing the `is_int()` and `ctype_digit()` check, the deprecation warning disappears. Haven't encountered any side-effects, as `is_int()` accepts any value (https://www.php.net/manual/en/function.is-int.php).

