### PR TITLE
Add 'withTrashed' routing support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.0, 8.1, 8.2 ]
-        laravel: [ 8, 9, 10 ]
+        laravel: [ 9, 10 ]
         stability: [ prefer-lowest, prefer-stable ]
         exclude:
           - php: 8.0
@@ -33,11 +33,6 @@ jobs:
           extensions: dom, curl, json, libxml, mbstring, zip
           tools: composer:v2
           coverage: none
-
-      - name: Patch testbench version
-        if: matrix.laravel == 8
-        run: |
-          composer require "orchestra/testbench=^6.23" --dev --no-interaction --no-update
 
       # https://github.com/briannesbitt/Carbon/releases/tag/2.62.1
       - name: Patch Carbon version

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 composer.phar
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/config": "^8.0|^9.0|^10.0",
-        "illuminate/container": "^8.0|^9.0|^10.0",
-        "illuminate/routing": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
+        "illuminate/config": "^9.0|^10.0",
+        "illuminate/container": "^9.0|^10.0",
+        "illuminate/routing": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
         "jenssegers/optimus": "^1.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <file>./src/Commands/FakeIdSetupCommand.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <file>./src/Commands/FakeIdSetupCommand.php</file>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/RoutesWithFakeIds.php
+++ b/src/RoutesWithFakeIds.php
@@ -23,24 +23,25 @@ trait RoutesWithFakeIds
     }
 
     /**
-     * Retrieve model for route model binding
+     * Retrieve the model for a bound value.
      *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function resolveRouteBinding($value, $field = null)
+    public function resolveRouteBindingQuery($query, $value, $field = null)
     {
         if (! (ctype_digit($value) || is_int($value))) {
-            return null;
+            return $query;
         }
 
         try {
             $value = App::make('fakeid')->decode((int) $value);
         } catch (Exception $e) {
-            return null;
+            return $query;
         }
 
-        return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
+        return $query->where($field ?? $this->getRouteKeyName(), $value);
     }
 }

--- a/tests/Entities/Deletable.php
+++ b/tests/Entities/Deletable.php
@@ -1,0 +1,12 @@
+<?php
+namespace Propaganistas\LaravelFakeId\Tests\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Propaganistas\LaravelFakeId\RoutesWithFakeIds;
+
+class Deletable extends Model
+{
+    use SoftDeletes;
+    use RoutesWithFakeIds;
+}


### PR DESCRIPTION
This PR supports Laravel-FakeId to be used with the Laravel 9 'withTrashed' on route level.

We implement this by simply moving the query to the `resolveRouteBindingQuery` method, instead of the original `resolveRouteBinding` method. Laravel 9's model's and up run the method `resolveRouteBinding` via the `resolveRouteBindingQuery`, so the behavior should be the same.

Dropped Laravel 8 support in the PR as well that's EOL.