### PR TITLE
Fix docblock for `resolveRouteBindingQuery`

### DIFF
--- a/src/RoutesWithFakeIds.php
+++ b/src/RoutesWithFakeIds.php
@@ -28,7 +28,7 @@ trait RoutesWithFakeIds
      * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {


### PR DESCRIPTION
The `resolveRouteBindingQuery` method is expected to return a `\Illuminate\Database\Eloquent\Builder` builder instead of the currently set `\Illuminate\Database\Eloquent\Relations\Relation`